### PR TITLE
bugfix: 修复光标在光标是否在字符串中间，删除字符，且删除的是分隔符后一位，则将光标位置前移到分隔符前的数字

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "input-formatting",
-  "version": "2.0.1",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/input-formatting/index.js
+++ b/src/input-formatting/index.js
@@ -143,10 +143,18 @@ export default class InputFormatting {
             selectionStart++
           }
         } else {
-          // 删除字符，且删除的是分隔符，则将分隔符前的数字一并删除，光标位置前移一位
-          if (selectionStart === delimiter.index) {
-            valueArray.splice(delimiter.index - 1, 1)
-            selectionStart--
+          // 判断光标是否在字符串中间
+          if (valueArray.length > selectionStart) {
+            // 删除字符，且删除的是分隔符后一位，则将光标位置前移到分隔符前的数字
+            if (selectionStart === delimiter.index + 1) {
+              selectionStart--
+            }
+          } else {
+            // 删除字符，且删除的是分隔符，则将分隔符前的数字一并删除，光标位置前移一位
+            if (selectionStart === delimiter.index) {
+              valueArray.splice(delimiter.index - 1, 1)
+              selectionStart--
+            }
           }
         }
 


### PR DESCRIPTION
修复光标在光标是否在字符串中间，删除字符时且删除的是分隔符后一位，则将光标位置前移到分隔符前的数字
行为与直接从最后删除到分隔符后一位一致